### PR TITLE
[#10] screenshot on test failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 
 /target/
 /.idea/
+/failedScreenshots/

--- a/src/test/java/cz/czechitas/automation/TestRunner.java
+++ b/src/test/java/cz/czechitas/automation/TestRunner.java
@@ -1,7 +1,9 @@
 package cz.czechitas.automation;
 
+import cz.czechitas.automation.extension.ScreenshotOnFailExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.openqa.selenium.WebDriver;
 import cz.czechitas.automation.assertion.AssertionFacade;
 
@@ -18,10 +20,14 @@ class TestRunner {
     protected final SeleniumActionFacade browser;
     protected final AssertionFacade asserter;
 
+    @RegisterExtension
+    final ScreenshotOnFailExtension screenshotExtension;
+
     public TestRunner() {
         this.webDriver = WebDriverProvider.getWebDriver();
         this.browser = new SeleniumActionFacade(webDriver);
         this.asserter = new AssertionFacade(webDriver);
+        this.screenshotExtension = new ScreenshotOnFailExtension(webDriver);
     }
 
     @BeforeEach

--- a/src/test/java/cz/czechitas/automation/extension/ScreenshotOnFailExtension.java
+++ b/src/test/java/cz/czechitas/automation/extension/ScreenshotOnFailExtension.java
@@ -1,0 +1,36 @@
+package cz.czechitas.automation.extension;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.TakesScreenshot;
+import org.openqa.selenium.WebDriver;
+
+import java.io.File;
+import java.io.IOException;
+
+public class ScreenshotOnFailExtension implements TestExecutionExceptionHandler {
+
+    private final WebDriver driver;
+
+    public ScreenshotOnFailExtension(WebDriver driver) {
+        this.driver = driver;
+    }
+
+    @Override
+    public void handleTestExecutionException(ExtensionContext context, Throwable cause) throws Throwable {
+
+        if (driver != null) {
+            File screenshotFile = ((TakesScreenshot) driver).getScreenshotAs(OutputType.FILE);
+            try {
+                String SCREENSHOT_DIRECTORY = "failedScreenshots/";
+                FileUtils.copyFile(screenshotFile, new File(SCREENSHOT_DIRECTORY + context.getDisplayName() + ".png"));
+            } catch (IOException e) {
+                System.out.println("Could not save taken screenshot: " + e);
+            }
+        }
+
+        throw cause; // Re-throw the exception to allow JUnit to handle it
+    }
+}

--- a/src/test/java/cz/czechitas/automation/extension/ScreenshotOnFailExtension.java
+++ b/src/test/java/cz/czechitas/automation/extension/ScreenshotOnFailExtension.java
@@ -9,8 +9,10 @@ import org.openqa.selenium.WebDriver;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
-public class ScreenshotOnFailExtension implements TestExecutionExceptionHandler {
+public final class ScreenshotOnFailExtension implements TestExecutionExceptionHandler {
 
     private final WebDriver driver;
 
@@ -23,14 +25,15 @@ public class ScreenshotOnFailExtension implements TestExecutionExceptionHandler 
 
         if (driver != null) {
             File screenshotFile = ((TakesScreenshot) driver).getScreenshotAs(OutputType.FILE);
+            String formattedTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss__"));
             try {
-                String SCREENSHOT_DIRECTORY = "failedScreenshots/";
-                FileUtils.copyFile(screenshotFile, new File(SCREENSHOT_DIRECTORY + context.getDisplayName() + ".png"));
+                String screenshotDir = "failedScreenshots/";
+                FileUtils.copyFile(screenshotFile, new File(screenshotDir + formattedTime + context.getDisplayName() + ".png"));
             } catch (IOException e) {
                 System.out.println("Could not save taken screenshot: " + e);
             }
         }
 
-        throw cause; // Re-throw the exception to allow JUnit to handle it
+        throw cause;
     }
 }


### PR DESCRIPTION
resolves #10 
I am not really fully satisfied with this solution but with test life cycle where we do quit browser in aftereach we cannot use testwatcher and I did always use TestNG so I do not know the better way how to do it in JUnit5 than this. Feel free to recommend some better solution.

@socker01 check it 🙏 